### PR TITLE
Resolve TypeError in embedding aggregation due to type inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ pip install transformers
 
 ## Data Preprocessing
 
+> **Note:** This repository uses([https://git-lfs.com/](https://git-lfs.com/)) for large data files. After cloning, please run `git lfs pull` to download the full data files.
+
 ```bash
 cd data
 python processed_data_gen.py
@@ -68,6 +70,8 @@ This script prepares graph structures and attaches sequence‑derived features u
 ---
 
 ## Training
+
+> **Note:** This framework requires a pre-trained DNAGPT model. Please see the instructions in `models/finetune_llm/checkpoints/README.md` to manually download `dna_gpt0.1b_h.pth` and place it in the checkpoints directory before running.
 
 ```bash
 python main-graphseqlm-gpt.py

--- a/main-graphseqlm-gpt.py
+++ b/main-graphseqlm-gpt.py
@@ -187,9 +187,13 @@ def train_model(nth, args, device):
         print("Embeddings generated and saved.")
 
     # Average the sequence emebedding
-    dna_embedding = np.mean(dna_embedding, axis=1).reshape(-1, 1)
-    rna_embedding = np.mean(rna_embedding, axis=1).reshape(-1, 1)
-    protein_embedding = np.mean(protein_embedding, axis=1).reshape(-1, 1)
+    dna_embedding = torch.tensor(dna_embedding)
+    rna_embedding = torch.tensor(rna_embedding)
+    protein_embedding = torch.tensor(protein_embedding)
+
+    dna_embedding = torch.mean(dna_embedding, dim=1).reshape(-1, 1)
+    rna_embedding = torch.mean(rna_embedding, dim=1).reshape(-1, 1)
+    protein_embedding = torch.mean(protein_embedding, dim=1).reshape(-1, 1)
 
     # Fetch sequence dimension
     dna_seq_dim = dna_embedding.shape[1]
@@ -339,9 +343,13 @@ def test_model(args, model, device, i):
     protein_embedding = np.load(form_data_path + '/protein_gpt_embedding.npy')
 
     # Average the sequence emebedding
-    dna_embedding = np.mean(dna_embedding, axis=1).reshape(-1, 1)
-    rna_embedding = np.mean(rna_embedding, axis=1).reshape(-1, 1)
-    protein_embedding = np.mean(protein_embedding, axis=1).reshape(-1, 1)
+    dna_embedding = torch.tensor(dna_embedding)
+    rna_embedding = torch.tensor(rna_embedding)
+    protein_embedding = torch.tensor(protein_embedding)
+
+    dna_embedding = torch.mean(dna_embedding, dim=1).reshape(-1, 1)
+    rna_embedding = torch.mean(rna_embedding, dim=1).reshape(-1, 1)
+    protein_embedding = torch.mean(protein_embedding, dim=1).reshape(-1, 1)
 
     dl_input_num = xTe.shape[0]
     batch_size = args.batch_size


### PR DESCRIPTION
Hi, I found and fixed a bug in main-graphseqlm-gpt.py that occurs due to inconsistent data types for the embedding variables.

The Problem: The variables dna_embedding, rna_embedding, and protein_embedding can be either:

A torch.Tensor (when generated live, if load_lm_embed=0)

A numpy.ndarray (when loaded from file, if load_lm_embed=1)

The original code np.mean(..., axis=1) fails in case 1, and a simple switch to torch.mean(..., dim=1) fails in case 2.

The Solution: This PR fixes the issue by first explicitly converting all embedding variables to PyTorch tensors using torch.tensor(). This ensures that the subsequent torch.mean(..., dim=1) operation always receives a tensor, making the code robust to both execution paths.

This fix is applied to both train_model and test_model functions.

Also updated the README.

Tested with Python 3.10 and PyTorch 2.8.0 + CUDA 12.8.